### PR TITLE
fix: handle quoted arguments

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} **/
 module.exports = {
   verbose: true,
-  testRegex: "/tests\\/.*\\.(test|spec)\\.tsx?$",
+  testRegex: "/tests\/.*\.(test|spec)\.tsx?$",
   testEnvironment: "node",
   transform: {
     "^.+.tsx?$": [

--- a/src/markup/args.ts
+++ b/src/markup/args.ts
@@ -71,12 +71,40 @@ export class ArgumentQueue {
     private pop0(rewind: boolean): Argument {
         const start: number = this.head;
         let c: number;
+        let inQuotes = false;
+        let quoteChar = 0;
+        let quoteStart = -1;
+
         while (this.head < this.data.length) {
             c = this.data.charCodeAt(this.head);
-            if (c === 58) break; // : (colon)
+
+            // Handle quotes (single or double)
+            if (c === 39 || c === 34) { // ' or "
+                if (!inQuotes) {
+                    inQuotes = true;
+                    quoteChar = c;
+                    quoteStart = this.head;
+                } else if (c === quoteChar) {
+                    inQuotes = false;
+                }
+            }
+
+            // Only break on colon if not inside quotes
+            if (c === 58 && !inQuotes) break; // : (colon)
+
             this.head++;
         }
-        const dat = this.data.substring(start, this.head);
+
+        let dat = this.data.substring(start, this.head);
+
+        // Strip quotes if the entire argument is quoted
+        if (quoteStart === start && quoteStart >= 0 && !inQuotes) {
+            const quoteEnd = this.head - 1;
+            if (this.data.charCodeAt(quoteEnd) === quoteChar) {
+                dat = this.data.substring(start + 1, quoteEnd);
+            }
+        }
+
         if (rewind) {
             this.head = start;
         } else {

--- a/tests/html/clickEvent.test.ts
+++ b/tests/html/clickEvent.test.ts
@@ -1,0 +1,27 @@
+import {Test, runTests, assertEquals} from "../junit";
+import MiniMessage from "../../src";
+
+class ClickEventTest {
+
+    @Test()
+    clickEventWithQuotedUrl() {
+        const mm = MiniMessage.miniMessage();
+        const src = `<click:open_url:'https://example.com'>Text</click>`;
+        const component = mm.deserialize(src);
+        
+        // Check that the component has the correct clickEvent
+        const clickEvent = component.getProperty("clickEvent")!;
+        assertEquals(clickEvent.action, "open_url");
+        assertEquals(clickEvent.value, "https://example.com");
+        
+        // Check that the HTML output is correct
+        const html = MiniMessage.miniMessage().toHTML(component);
+        
+        // The HTML should contain a data-mm-click-event attribute with the correct JSON
+        const expectedAttr = `data-mm-click-event="{\\\"action\\\":\\\"open_url\\\",\\\"value\\\":\\\"https://example.com\\\"}"`;
+        const containsExpectedAttr = html.includes(expectedAttr);
+        assertEquals(containsExpectedAttr, true);
+    }
+}
+
+runTests(ClickEventTest);

--- a/tests/markup/args.test.ts
+++ b/tests/markup/args.test.ts
@@ -31,6 +31,33 @@ class ArgumentQueueTest {
         ArgumentQueue.EMPTY.pop();
     }
 
+    @Test()
+    quotedArguments() {
+        // Test with single quotes
+        let queue = new ArgumentQueue("'hello world':unquoted:'quoted:value'");
+
+        let arg1 = queue.pop().value;
+        assertEquals("hello world", arg1);
+
+        let arg2 = queue.pop().value;
+        assertEquals("unquoted", arg2);
+
+        let arg3 = queue.pop().value;
+        assertEquals("quoted:value", arg3);
+
+        // Test with double quotes
+        queue = new ArgumentQueue('"double quoted":unquoted:"quoted:value"');
+
+        arg1 = queue.pop().value;
+        assertEquals("double quoted", arg1);
+
+        arg2 = queue.pop().value;
+        assertEquals("unquoted", arg2);
+
+        arg3 = queue.pop().value;
+        assertEquals("quoted:value", arg3);
+    }
+
 }
 
 runTests(ArgumentQueueTest);


### PR DESCRIPTION
# Fix for Quoted Arguments in MiniMessage Links

## Problem
MiniMessage links with quoted URLs were not being processed correctly. When using syntax like `<click:open_url:'https://example.com'>Text</click>`, the quotes were not being properly handled, resulting in the URL value containing the quotes.

## Solution
The solution was implemented at the argument parsing level in the `Argument` class:

1. Modified the `pop0` method in `Argument` to recognize and handle text within quotes (both single and double quotes)
2. Added logic to prevent splitting on colons that appear within quoted strings
3. Implemented automatic quote stripping for fully quoted arguments

## Testing
- Added a dedicated test case in `tests/html/clickEvent.test.ts` to verify that URLs in click events are correctly processed
- Added comprehensive tests for quoted arguments in `tests/markup/args.test.ts`
- All tests are passing, confirming that the implementation works correctly

## Additional Notes
This change improves the handling of quoted arguments throughout the codebase, not just for click events. Any tag that uses the `Argument` class will now correctly handle quoted arguments, making the library more robust and consistent with the original MiniMessage specification.