### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -54,7 +54,7 @@ jobs:
         rm -rf types tests src node_modules buildSrc packages/translations
 
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
       with:
         path: './'
 
@@ -67,4 +67,4 @@ jobs:
     steps:
     - name: Deploy
       id: deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
The CI has seemingly [fallen out of date](https://github.com/WasabiThumb/minimessage-js/actions/runs/16084121567/job/45393019159); fixing this will allow the web demo to update