### PR TITLE
Fix player heads not rendering due to mixed content policy

### DIFF
--- a/src/html/effects/playerHead/online.ts
+++ b/src/html/effects/playerHead/online.ts
@@ -27,6 +27,15 @@ export namespace OnlineHeads {
         return null;
     }
 
+    function upgradeHTTP(url: string): string {
+        // The texture link provided by the mojang API is http
+        // despite also supporting https. Browsers
+        // consistently block this request instead of upgrading
+        // it, so we do this manually.
+        if (!url.startsWith("http:")) return url;
+        return "https:" + url.substring(5);
+    }
+
     /**
      * Provides an object URL containing the
      * face texture of the given online user, with or without
@@ -47,7 +56,10 @@ export namespace OnlineHeads {
         const skin = textures["SKIN"];
         if (!skin) return null;
 
-        const bitmap = await fetch(skin.url, { cache: "force-cache" })
+        let skinUrl = skin.url;
+        skinUrl = upgradeHTTP(skinUrl);
+
+        const bitmap = await fetch(skinUrl, { cache: "force-cache" })
             .then((r) => r.blob())
             .then((blob) => createImageBitmap(blob));
 


### PR DESCRIPTION
The mojang ([CORSjang](https://corsjang.b-cdn.net/)) API consistently provides skin textures as ``http:`` URLs despite also supporting ``https:``. Browsers consistently fail to upgrade these requests, instead erroring due to [Mixed content](https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Mixed_content) policy:
<img width="1054" height="122" alt="image" src="https://github.com/user-attachments/assets/5319e922-bdbb-4a7f-9af2-28f1fe1de909" />

This PR adds some code to manually upgrade these URLs before making the request.
