### PR TITLE
fix: named color parsing

### DIFF
--- a/src/serializer/json.ts
+++ b/src/serializer/json.ts
@@ -262,8 +262,11 @@ class JsonComponentSerializerImpl implements JsonComponentSerializer {
                     let color: TextColor | null = TextColor.fromHexString(jsonColor);
                     if (color === null) {
                         const token = jsonColor.toLowerCase();
-                        if (token in NamedTextColor.NAMES) color = NamedTextColor.NAMES[token];
-                        throw new Error(`Unable to parse color: ${jsonColor}`);
+                        if (token in NamedTextColor.NAMES) {
+                            color = NamedTextColor.NAMES[token];
+                        } else {
+                            throw new Error(`Unable to parse color: ${jsonColor}`);
+                        }
                     }
                     style.color(color);
                     break;


### PR DESCRIPTION
This pull request makes a small improvement to the color parsing logic in the `JsonComponentSerializerImpl` class. The change ensures that an error is only thrown if the provided color string is not a valid named color, resulting in clearer and more robust error handling.

* Improved error handling in `JsonComponentSerializerImpl`: Now only throws an error if the color string is not found in `NamedTextColor.NAMES`, making the logic clearer and preventing unintended exceptions.